### PR TITLE
[Migration]: OAuth 인증 스키마 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
     "db:generate": "npx prisma generate",
     "db:push": "npx prisma db push",
     "db:status": "npx prisma migrate status",
-    
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "docker:logs": "docker-compose logs -f postgres"    
+    "docker:logs": "docker-compose logs -f postgres"
   },
   "keywords": [
     "study",

--- a/prisma/migrations/20250915174551_oauth_migration/migration.sql
+++ b/prisma/migrations/20250915174551_oauth_migration/migration.sql
@@ -1,4 +1,7 @@
 -- CreateEnum
+CREATE TYPE "public"."OAuthProvider" AS ENUM ('GOOGLE', 'APPLE', 'FACEBOOK');
+
+-- CreateEnum
 CREATE TYPE "public"."SessionStatus" AS ENUM ('ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED');
 
 -- CreateEnum
@@ -10,7 +13,6 @@ CREATE TYPE "public"."TaskPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
 -- CreateTable
 CREATE TABLE "public"."users" (
     "id" TEXT NOT NULL,
-    "firebase_uid" VARCHAR(128) NOT NULL,
     "email" VARCHAR(255) NOT NULL,
     "nickname" VARCHAR(50) NOT NULL,
     "display_name" VARCHAR(100),
@@ -23,6 +25,19 @@ CREATE TABLE "public"."users" (
     "updated_at" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."oauth_accounts" (
+    "id" TEXT NOT NULL,
+    "provider" "public"."OAuthProvider" NOT NULL,
+    "provider_id" VARCHAR(100) NOT NULL,
+    "provider_data" JSONB,
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "oauth_accounts_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -103,16 +118,16 @@ CREATE TABLE "public"."daily_summaries" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "users_firebase_uid_key" ON "public"."users"("firebase_uid");
-
--- CreateIndex
 CREATE UNIQUE INDEX "users_email_key" ON "public"."users"("email");
 
 -- CreateIndex
-CREATE INDEX "idx_users_firebase_uid" ON "public"."users"("firebase_uid");
+CREATE INDEX "idx_users_email" ON "public"."users"("email");
 
 -- CreateIndex
-CREATE INDEX "idx_users_email" ON "public"."users"("email");
+CREATE INDEX "idx_oauth_accounts_user" ON "public"."oauth_accounts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "oauth_accounts_provider_provider_id_key" ON "public"."oauth_accounts"("provider", "provider_id");
 
 -- CreateIndex
 CREATE INDEX "idx_subjects_user_id" ON "public"."subjects"("user_id");
@@ -146,6 +161,9 @@ CREATE INDEX "idx_daily_summaries_user_date" ON "public"."daily_summaries"("user
 
 -- CreateIndex
 CREATE UNIQUE INDEX "daily_summaries_user_id_date_key" ON "public"."daily_summaries"("user_id", "date");
+
+-- AddForeignKey
+ALTER TABLE "public"."oauth_accounts" ADD CONSTRAINT "oauth_accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."subjects" ADD CONSTRAINT "subjects_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,12 @@ datasource db {
 
 // Enums (데이터 무결성 보장)
 
+enum OAuthProvider{
+  GOOGLE
+  APPLE
+  FACEBOOK
+}
+
 enum SessionStatus {
   ACTIVE    // 진행 중
   PAUSED    // 일시정지
@@ -37,8 +43,7 @@ enum TaskPriority {
 model User {
   id           String   @id @default(cuid())
   
-  // Firebase Authentication 연동 필드
-  firebaseUid  String   @unique @map("firebase_uid") @db.VarChar(128)
+  // 핵심 사용자 정보
   email        String   @unique @db.VarChar(255)
   nickname     String   @db.VarChar(50)
   displayName  String?  @map("display_name") @db.VarChar(100)
@@ -54,6 +59,9 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
+  // OAuth 계정 연결(1:N 관계 - 한 사용자가 여러 Provider 연결 가능)
+  oauthAccounts OAuthAccount[]
+
   // 관계 정의
   subjects       Subject[]
   studySessions  StudySession[]
@@ -61,12 +69,34 @@ model User {
   dailySummaries DailySummary[]
 
   @@map("users")
-  @@index([firebaseUid], name: "idx_users_firebase_uid")
   @@index([email], name: "idx_users_email")
 }
 
-// 과목/카테고리 관리
+// OAuth 걔정 연결 정보
+model OAuthAccount{
+  id      String      @id @default(cuid())
 
+  // OAuth 제공자 정보
+  provider  OAuthProvider
+  providerId  String   @map("provider_id")@db.VarChar(100) // Provider의 고유 사용자 ID
+
+  // 제공자별 추가 정보(JSON으로 유연하게 저장)
+  // 예: Google의 경우 {sub, name, email, picture, email_verified}
+  providerData  Json?  @map("provider_data")
+
+  // 사용자 관계
+  userId String @map("user_id")
+  user  User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("oauth_accounts")
+  @@unique([provider, providerId], name: "unique_provider_account")// Provider별 계정 중복 방지
+  @@index([userId], name: "idx_oauth_accounts_user")
+}
+
+// 과목/카테고리 관리
 model Subject {
   id          String  @id @default(cuid())
   name        String  @db.VarChar(100)

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ app.use(express.urlencoded({extended: true}))
 // 라우터 연결
 app.use('/', healthRouter)
 
+
 // 404 핸들러 
 app.use((req, res) => {
     res.status(404).json({


### PR DESCRIPTION
## 연관 이슈
> Closes #4 

## 개요
> 현재 Firebase Authentication 기반으로 구축된 인증 시스템을 OAuth 2.0 표준 기반의 자체 인증 시스템으로 전환

## 목표
- Firebase 의존성 제거 및 OAuth 2.0 표준 준수
- 다중 OAuth Provider 지원 가능한 확장 구조 구축