### PR TITLE
[FEAT] 과목 관리 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "morgan": "^1.10.1",
         "node-jose": "^2.2.0",
         "passport": "^0.7.0",
-        "passport-google-oauth20": "^2.0.0"
+        "passport-google-oauth20": "^2.0.0",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -4157,6 +4158,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "morgan": "^1.10.1",
     "node-jose": "^2.2.0",
     "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,9 +13,13 @@ dotenv.config();
 // 데이터베이스 연결
 import { connectDatabase } from './lib/prisma';
 
+// 에러 핸들러
+import { errorHandler } from './middleware/error-handler';
+
 // 라우터 import
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
+import subjectRouter from './routes/subject';
 
 const app = express()
 
@@ -50,6 +54,7 @@ app.use(express.urlencoded({extended: true}))
 // 라우터 연결
 app.use('/', healthRouter)
 app.use('/api/auth', authRouter)
+app.use('/', subjectRouter)
 
 // 기본 라우트들
 app.get('/', (req, res) => {
@@ -80,13 +85,7 @@ app.use((req, res) => {
 });
 
 // 전역 예외 핸들러
-app.use((error: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
-    console.error('Unhandled error:', error);
-    res.status(500).json({
-        error: 'Internal Server Error',
-        message: process.env.NODE_ENV === 'development' ? error.message : 'Something went wrong'
-    });
-});
+app.use(errorHandler as any);
 
 const PORT = process.env.PORT || 3000;
 

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction } from "express";
+import { z, ZodError } from "zod";
+
+export function errorHandler(
+    error: Error | ZodError,
+    req: Request,
+    res: Response,
+    next: NextFunction
+){
+    console.error('API Error', {
+        message: error.message,
+        url: req.url,
+        method: req.method,
+        userId: (req as any).user?.id
+    })
+
+    // Zod 검증 오류
+    if(error instanceof ZodError){
+        return res.status(400).json({
+            error: 'Validation Error',
+            message: '입력 데이터가 올바르지 않습니다',
+            details: (error as ZodError).issues.map(err => ({
+                field: err.path.join('.'),
+                message: err.message
+            }))
+        })
+    }
+
+    // 비즈니스 로직 오류
+    if(error.message === 'SUBJECT_NOT FOUND'){
+        return res.status(404).json({
+            error: 'Subject Not Found',
+            message: '요청한 과목을 찾을 수 없습니다'
+        })
+    }
+
+    if(error.message === 'SUBJECT_NAME_DUPLICATE'){
+        return res.status(409).json({
+            error: 'Duplicate Subject Name',
+            message: '이미 같은 이름의 과목이 존재합니다'
+        })
+    }
+
+    // 기본 서버 오류
+    res.status(500).json({
+        error: 'Internal Server Error',
+        message: process.env.NODE_ENV === 'development'
+            ? error.message
+            : '서버 내부 오류가 발생했습니다'
+    })
+}

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -11,7 +11,7 @@ export function errorHandler(
         message: error.message,
         url: req.url,
         method: req.method,
-        userId: (req as any).user?.id
+        userId: (req as any).user?.userId
     })
 
     // Zod 검증 오류
@@ -27,7 +27,7 @@ export function errorHandler(
     }
 
     // 비즈니스 로직 오류
-    if(error.message === 'SUBJECT_NOT FOUND'){
+    if(error.message === 'SUBJECT_NOT_FOUND'){
         return res.status(404).json({
             error: 'Subject Not Found',
             message: '요청한 과목을 찾을 수 없습니다'

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -219,6 +219,42 @@ router.post('/refresh', async (req, res) => {
     }
 });
 
+// 토큰 조회 (개발/테스트용)
+router.get('/tokens', async (req, res) => {
+    try {
+        const accessToken = req.cookies.accessToken || req.headers.authorization?.replace('Bearer ', '');
+        const refreshToken = req.cookies.refreshToken;
+
+        if (!accessToken && !refreshToken) {
+            return res.status(401).json({ 
+                error: 'No tokens found',
+                message: '토큰이 없습니다. 로그인이 필요합니다.'
+            });
+        }
+
+        // 개발 환경에서만 토큰 값을 반환
+        if (process.env.NODE_ENV === 'development') {
+            return res.json({
+                success: true,
+                accessToken: accessToken || null,
+                refreshToken: refreshToken || null,
+                hasAccessToken: !!accessToken,
+                hasRefreshToken: !!refreshToken
+            });
+        }
+
+        // 프로덕션에서는 토큰 존재 여부만 반환
+        return res.json({
+            success: true,
+            hasAccessToken: !!accessToken,
+            hasRefreshToken: !!refreshToken
+        });
+    } catch (error) {
+        console.error('Token retrieval error:', error);
+        res.status(500).json({ error: 'Failed to retrieve tokens' });
+    }
+});
+
 // 로그아웃
 router.post('/logout', (req, res) => {
     res.clearCookie('accessToken');

--- a/src/routes/subject.ts
+++ b/src/routes/subject.ts
@@ -2,8 +2,6 @@ import { Router } from "express";
 import { authenticateToken } from "../middleware/auth";
 import { createSubjectSchema, subjectParamsSchema, subjectQuerySchema, updateSubjectSchema } from "../schemas/subject.schema";
 import { SubjectService } from "../services/subject.service";
-import { success } from "zod";
-import { errorHandler } from "../middleware/error-handler";
 
 const router = Router()
 
@@ -11,7 +9,7 @@ const router = Router()
 router.use(authenticateToken as any)
 
 // 과목 목록 조회(GET/subjects)
-router.get('/', async(req, res, next) => {
+router.get('/subjects', async(req, res, next) => {
     try{
         const query = subjectQuerySchema.parse(req.query)
         const result = await SubjectService.getSubjectsByUserId((req as any).user!.userId, query)
@@ -27,10 +25,10 @@ router.get('/', async(req, res, next) => {
 })
 
 // 과목 생성(POST/subjects)
-router.post('/', async (req, res, next) => {
+router.post('/subjects', async (req, res, next) => {
     try{
         const data = createSubjectSchema.parse(req.body)
-        const subject = await SubjectService.createSubject((req as any).user!.id, data)
+        const subject = await SubjectService.createSubject((req as any).user!.userId, data)
 
         res.status(201).json({
             success: true,
@@ -43,10 +41,10 @@ router.post('/', async (req, res, next) => {
 })
 
 // 특정 과목 조회(GET/subjects/:id)
-router.get('/:id', async(req, res, next) => {
+router.get('/subjects/:id', async(req, res, next) => {
     try{
         const {id} = subjectParamsSchema.parse(req.params)
-        const subject = await SubjectService.getSubjectById(id, (req as any).user!.id)
+        const subject = await SubjectService.getSubjectById(id, (req as any).user!.userId)
 
         res.json({
             success: true,
@@ -58,7 +56,7 @@ router.get('/:id', async(req, res, next) => {
 })
 
 // 과목 수정(PATCH/subjects/:id)
-router.patch('/:id', async (req, res, next) => {
+router.patch('/subjects/:id', async (req, res, next) => {
     try{
         const {id} = subjectParamsSchema.parse(req.params)
         const data = updateSubjectSchema.parse(req.body)
@@ -70,7 +68,7 @@ router.patch('/:id', async (req, res, next) => {
             })
         }
 
-        const subject = await SubjectService.updateSubject(id, (req as any).user!.id, data)
+        const subject = await SubjectService.updateSubject(id, (req as any).user!.userId, data)
 
         res.json({
             success: true,
@@ -83,10 +81,10 @@ router.patch('/:id', async (req, res, next) => {
 })
 
 // 과목 삭제(DELETE/subjects/:id)
-router.delete('/:id', async (req, res, next) => {
+router.delete('/subjects/:id', async (req, res, next) => {
     try{
         const {id} =  subjectParamsSchema.parse(req.params)
-        const result = await SubjectService.deleteSubject(id, (req as any).user!.id)
+        const result = await SubjectService.deleteSubject(id, (req as any).user!.userId)
 
         let message = "과목이 성공적으로 삭제되었습니다"
         if(result.deletedRelatedData.studySessions > 0 || result.deletedRelatedData.planTasks > 0){
@@ -102,8 +100,5 @@ router.delete('/:id', async (req, res, next) => {
         next(error)
     }
 })
-
-// 에러 핸들링 미들웨어 적용
-router.use(errorHandler)
 
 export default router

--- a/src/routes/subject.ts
+++ b/src/routes/subject.ts
@@ -1,0 +1,109 @@
+import { Router } from "express";
+import { authenticateToken } from "../middleware/auth";
+import { createSubjectSchema, subjectParamsSchema, subjectQuerySchema, updateSubjectSchema } from "../schemas/subject.schema";
+import { SubjectService } from "../services/subject.service";
+import { success } from "zod";
+import { errorHandler } from "../middleware/error-handler";
+
+const router = Router()
+
+// 모든 라우트에 인증 미들웨어 적용
+router.use(authenticateToken as any)
+
+// 과목 목록 조회(GET/subjects)
+router.get('/', async(req, res, next) => {
+    try{
+        const query = subjectQuerySchema.parse(req.query)
+        const result = await SubjectService.getSubjectsByUserId((req as any).user!.userId, query)
+        
+        res.json({
+            success: true,
+            data: result.subjects,
+            pagination: result.pagination
+        })
+    } catch(error){
+        next(error)
+    }
+})
+
+// 과목 생성(POST/subjects)
+router.post('/', async (req, res, next) => {
+    try{
+        const data = createSubjectSchema.parse(req.body)
+        const subject = await SubjectService.createSubject((req as any).user!.id, data)
+
+        res.status(201).json({
+            success: true,
+            message: '과목이 성공적으로 생성되었습니다',
+            data: subject
+        })
+    }catch(error){
+        next(error)
+    }
+})
+
+// 특정 과목 조회(GET/subjects/:id)
+router.get('/:id', async(req, res, next) => {
+    try{
+        const {id} = subjectParamsSchema.parse(req.params)
+        const subject = await SubjectService.getSubjectById(id, (req as any).user!.id)
+
+        res.json({
+            success: true,
+            data: subject
+        })
+    }catch(error){
+        next(error)
+    }
+})
+
+// 과목 수정(PATCH/subjects/:id)
+router.patch('/:id', async (req, res, next) => {
+    try{
+        const {id} = subjectParamsSchema.parse(req.params)
+        const data = updateSubjectSchema.parse(req.body)
+
+        if(Object.keys(data).length === 0){
+            return res.status(400).json({
+                error: 'Validation Error',
+                message: '수정할 데이터를 입력해주세요'
+            })
+        }
+
+        const subject = await SubjectService.updateSubject(id, (req as any).user!.id, data)
+
+        res.json({
+            success: true,
+            message: '과목이 성공적으로 수정되었습니다',
+            data: subject
+        })
+    }catch(error){
+        next(error)
+    }
+})
+
+// 과목 삭제(DELETE/subjects/:id)
+router.delete('/:id', async (req, res, next) => {
+    try{
+        const {id} =  subjectParamsSchema.parse(req.params)
+        const result = await SubjectService.deleteSubject(id, (req as any).user!.id)
+
+        let message = "과목이 성공적으로 삭제되었습니다"
+        if(result.deletedRelatedData.studySessions > 0 || result.deletedRelatedData.planTasks > 0){
+            message += `(관련 학습 세션 ${result.deletedRelatedData.studySessions}개, 계획 과업 ${result.deletedRelatedData.planTasks}개도 함께 삭제되었습니다)`
+        }
+
+        res.json({
+            success: true,
+            message,
+            delta: result
+        })
+    }catch(error){
+        next(error)
+    }
+})
+
+// 에러 핸들링 미들웨어 적용
+router.use(errorHandler)
+
+export default router

--- a/src/schemas/subject.schema.ts
+++ b/src/schemas/subject.schema.ts
@@ -43,6 +43,6 @@ export const subjectQuerySchema = z.object({
 })
 
 export type CreateSubjectInput = z.infer<typeof createSubjectSchema>
-export type UpdateSubjectSchema = z.infer<typeof updateSubjectSchema>
+export type UpdateSubjectInput = z.infer<typeof updateSubjectSchema>
 export type SubjectParams = z.infer<typeof subjectParamsSchema>
 export type SubjectQuery = z.infer<typeof subjectQuerySchema>

--- a/src/schemas/subject.schema.ts
+++ b/src/schemas/subject.schema.ts
@@ -1,0 +1,48 @@
+import z from "zod"
+
+
+const hexColorRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+const emojiRegex = /^[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]$/u
+
+export const createSubjectSchema = z.object({
+    name: z.string()
+        .min(1, '과목명은 필수입니다')
+        .max(100, '과목명은 100자 이하여야 합니다')
+        .trim(),
+
+    color: z.string()
+        .regex(hexColorRegex, '올바른 색상 코드를 입력해주세요')
+        .default('#3B82F6'),
+    
+    icon: z.string()
+        .max(10, '아이콘은 10자 이하여야 합니다')
+        .optional()
+        .refine((val) => !val || emojiRegex.test(val) || val.length <= 2, {
+            message: '올바른 이모지 또는 간단한 아이콘을 입력해주세요'
+        }),
+    description: z.string()
+        .max(500, '설명은 500자 이하여야 합니다')
+        .trim()
+        .optional()
+        .transform(val => val === ''? null: val)
+    
+})
+
+export const updateSubjectSchema = createSubjectSchema.partial()
+
+export const subjectParamsSchema = z.object({
+    id: z.string().cuid('올바른 과목 ID가 아닙니다')
+})
+
+export const subjectQuerySchema = z.object({
+    search: z.string().optional(),
+    limit: z.coerce.number().min(1).max(100).default(20),
+    offset: z.coerce.number().min(0).default(0),
+    sortBy: z.enum(['name', 'createdAt', 'updatedAt']).default('name'),
+    sortOrder: z.enum(['asc', 'desc']).default('asc')
+})
+
+export type CreateSubjectInput = z.infer<typeof createSubjectSchema>
+export type UpdateSubjectSchema = z.infer<typeof updateSubjectSchema>
+export type SubjectParams = z.infer<typeof subjectParamsSchema>
+export type SubjectQuery = z.infer<typeof subjectQuerySchema>

--- a/src/services/subject.service.ts
+++ b/src/services/subject.service.ts
@@ -1,0 +1,185 @@
+import { prisma } from "../lib/prisma";
+import { CreateSubjectInput, SubjectQuery, UpdateSubjectInput } from "../schemas/subject.schema";
+
+
+export class SubjectService{
+    // 사용자의 모든 과목 조회
+    static async getSubjectsByUserId(userId: string, query: SubjectQuery){
+        const {search, limit, offset, sortBy, sortOrder} = query
+
+        const where = {
+            userId,
+            ...(search && {
+                OR: [
+                    {name: {contains: search, mode: 'insensitive' as const}},
+                    {description: {contains: search, mode: 'insensitive' as const}}
+                ]
+            })
+        }
+
+        const orderBy = {[sortBy]: sortOrder}
+
+        const [subjects, total] = await Promise.all([
+            prisma.subject.findMany({
+                where,
+                orderBy,
+                skip: offset,
+                take: limit,
+                select:{
+                    id: true,
+                    name: true,
+                    color: true,
+                    icon: true,
+                    description: true,
+                    createdAt: true,
+                    updatedAt: true,
+                    _count: {
+                        select: {
+                            studySessions: true,
+                            planTasks: true
+                        }
+                    }
+                }
+            }),
+            prisma.subject.count({where})
+        ])
+
+        return{
+            subjects: subjects.map(subject => ({
+                ...subject,
+                stats: subject._count,
+            })),
+            pagination: {
+                total,
+                limit,
+                offset,
+                hasNext: offset + limit < total
+            }
+        }
+    }
+
+    // 특정 과목 조회(소유권 검증 포함)
+    static async getSubjectById(id: string, userId: string){
+        const subject = await prisma.subject.findFirst({
+            where: {id, userId},
+            select: {
+                id: true,
+                name: true,
+                color: true,
+                icon: true,
+                description: true,
+                createdAt: true,
+                updatedAt: true,
+                _count: {
+                    select: {
+                        studySessions: true,
+                        planTasks: true
+                    }
+                }
+            }
+        })
+
+        if(!subject){
+            throw new Error('SUBJECT_NOT_FOUND')
+        }
+
+        return {
+            ...subject,
+            stats: subject._count
+        }
+    }
+
+    // 과목 생성(중복명 검사 포함)
+    static async createSubject(userId: string, data: CreateSubjectInput){
+        const existingSubject = await prisma.subject.findFirst({
+            where: {
+                userId,
+                name: {equals: data.name, mode: 'insensitive'}
+            }
+        })
+
+        if(existingSubject){
+            throw new Error('SUBJECT_NAME_DUPLICATE')
+        }
+
+        return await prisma.subject.create({
+            data: {...data, userId},
+            select: {
+                id: true,
+                name: true,
+                color: true,
+                icon: true,
+                description: true,
+                createdAt: true,
+                updatedAt: true
+            }
+        })
+    }
+
+    // 과목 수정
+    static async updateSubject(id: string, userId: string, data: UpdateSubjectInput){
+        const existingSubject = await prisma.subject.findFirst({
+            where: {id, userId}
+        })
+
+        if(!existingSubject){
+            throw new Error('SUBJECT_NOT_FOUND')
+        }
+
+        // 이름 변경 시 중복 검사
+        if(data.name && data.name !== existingSubject.name){
+            const duplicateSubject = await prisma.subject.findFirst({
+                where: {
+                    userId,
+                    name: {equals: data.name, mode: 'insensitive'},
+                    id: {not: id}
+                }
+            })
+
+            if(duplicateSubject){
+                throw new Error('SUBJECT_NAME_DUPLICATE')
+            }
+        }
+
+        return await prisma.subject.update({
+            where: {id},
+            data,
+            select: {
+                id: true,
+                name: true,
+                color: true,
+                icon: true,
+                description: true,
+                createdAt: true,
+                updatedAt: true,
+            }
+        })
+    }
+
+
+    // 과목 삭제
+    static async deleteSubject(id: string, userId: string){
+        const subject = await prisma.subject.findFirst({
+            where: {id, userId},
+            include: {
+                _count: {
+                    select: {
+                        studySessions: true,
+                        planTasks: true
+                    }
+                }
+            }
+        })
+
+        if(!subject){
+            throw new Error('SUBJECT_NOT_FOUND')
+        }
+
+        await prisma.subject.delete({where: {id}})
+
+        return {
+            deletedSubject: {id: subject.id, name: subject.name},
+            deletedRelatedData: subject._count
+        }
+    }
+}


### PR DESCRIPTION
## 연관 이슈
> Closes #8 

## 구현 내용
> 사용자별 과목/카테고리 관리를 위한 CRUD API 구현

## 구현한 파일들
- subject.schema.ts - Zod 기반 입력 검증 스키마
- subject.service.ts - 비즈니스 로직 서비스 레이어
- subjects.ts - 4가지 API 구현
    - GET/subjects: 과목 목록 조회
    - POST/subjects: 과목 생성
    - GET/subjects/:id: 특정 과목 조회
    - PATCH/subjects/:id: 과목 수정
    - DELETE/subjects/:id - 과목 삭제
- error-handler.ts - 에러 처리 미들웨어